### PR TITLE
feature: add the new project template for note script (counter)

### DIFF
--- a/note/template/Cargo.toml
+++ b/note/template/Cargo.toml
@@ -1,0 +1,60 @@
+[package]
+name = "{{crate_name}}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+# Build this crate as a self-contained, C-style dynamic library
+# This is required to emit the proper Wasm module type
+crate-type = ["cdylib"]
+
+[dependencies]
+# Miden SDK consists of a stdlib (intrinsic functions for VM ops, stdlib functions and types)
+# and transaction kernel API for the Miden rollup
+{% if compiler_path %}
+miden = { path = "{{ compiler_path }}/sdk/sdk" }
+{% elsif compiler_branch %}
+miden = { git = "https://github.com/0xPolygonMiden/compiler", branch = "{{ compiler_branch }}" }
+{% elsif compiler_rev %}
+miden = { git = "https://github.com/0xPolygonMiden/compiler", rev = "{{ compiler_rev }}" }
+{% else %}
+miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+{% endif %}
+wit-bindgen-rt = "0.28"
+
+[package.metadata.component]
+package = "miden:{{crate_name | replace: "_", "-"}}"
+
+# Miden dependencies for cargo-miden build/linking
+[package.metadata.miden.dependencies]
+# Path to the counter-contract cargo project. Can be created with `cargo miden new [name]`
+"miden:counter-contract" = { path = "../counter-contract" }
+
+[package.metadata.component.target.dependencies]
+"miden:base" = { path = "wit-deps/miden.wit" }
+"miden:core-intrinsics" = { path = "wit-deps/miden-core-intrinsics.wit" }
+"miden:core-stdlib" = { path = "wit-deps/miden-core-stdlib.wit" }
+"miden:core-base" = { path = "wit-deps/miden-core-base.wit" }
+# The WIT file from the counter contract 
+"miden:counter-contract" = { path = "../counter-contract/wit/interface.wit" }
+
+[profile.release]
+# optimize the output for size
+opt-level = "z"
+# Explicitly disable panic infrastructure on Wasm, as
+# there is no proper support for them anyway, and it
+# ensures that panics do not pull in a bunch of standard
+# library code unintentionally
+panic = "abort"
+
+[profile.dev]
+# Explicitly disable panic infrastructure on Wasm, as
+# there is no proper support for them anyway, and it
+# ensures that panics do not pull in a bunch of standard
+# library code unintentionally
+panic = "abort"
+opt-level = 1
+debug-assertions = true
+overflow-checks = false
+debug = true
+

--- a/note/template/README.md
+++ b/note/template/README.md
@@ -1,0 +1,15 @@
+# {{crate_name}}
+
+# Before compiling 
+
+This project depends on the counter contract which can be created with `cargo miden new counter-contract` and put in the adjacent folder.
+If you already have counter contract under different name all `counter-contract` references in `Cargo.toml`, `interface.wit`, `lib.rs` (`counter_contract` import) should be updated to point to your counter contract (name/path).
+
+## Useful commands
+
+`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).  
+
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+for more details on how to build and run the compiled programs.
+
+

--- a/note/template/cargo-generate.toml
+++ b/note/template/cargo-generate.toml
@@ -1,0 +1,3 @@
+[template]
+cargo_generate_version = ">=0.18.0"
+ignore = ["target/", "Cargo.lock"]

--- a/note/template/rust-toolchain.toml
+++ b/note/template/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2025-03-20"
+components = ["rustfmt", "rust-src"]
+targets = ["wasm32-wasi"]
+profile = "minimal"

--- a/note/template/src/lib.rs
+++ b/note/template/src/lib.rs
@@ -1,0 +1,40 @@
+// Do not link against libstd (i.e. anything defined in `std::`)
+#![no_std]
+
+// However, we could still use some standard library types while
+// remaining no-std compatible, if we uncommented the following lines:
+//
+// extern crate alloc;
+// use alloc::vec::Vec;
+
+// Global allocator to use heap memory in no-std environment
+#[global_allocator]
+static ALLOC: miden::BumpAlloc = miden::BumpAlloc::new();
+
+// Required for no-std crates
+#[cfg(not(test))]
+#[panic_handler]
+fn my_panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+bindings::export!(IncrementCounterNote with_types_in bindings);
+
+mod bindings;
+
+use bindings::{
+    exports::miden::base::note_script::Guest, miden::counter_contract::counter_contract,
+};
+use miden::*;
+
+struct IncrementCounterNote;
+
+impl Guest for IncrementCounterNote {
+    fn note_script() {
+        let initial_value = counter_contract::get_count();
+        counter_contract::increment_count();
+        let expected_value = initial_value + Felt::from_u32(1);
+        let final_value = counter_contract::get_count();
+        assert_eq(final_value, expected_value);
+    }
+}

--- a/note/template/wit/interface.wit
+++ b/note/template/wit/interface.wit
@@ -1,0 +1,12 @@
+package miden:{{crate_name | replace: "_", "-"}}@0.1.0;
+
+world counter-note-world {
+    include miden:core-intrinsics/intrinsics@1.0.0;
+    include miden:core-stdlib/stdlib@1.0.0;
+    include miden:core-base/base@1.0.0;
+
+    // Change it to the package name defined in the WIT file of the counter contract
+    import miden:counter-contract/counter-contract@0.1.0;
+
+    export miden:base/note-script@1.0.0;
+}


### PR DESCRIPTION
This PR adds a new project template for `cargo miden new --note [name]` note script and sets the `v0.10.0` tag used in https://github.com/0xMiden/compiler/pull/511