### PR TITLE
chore: remove `wasm32-wasi` in favor of `wasm32-wasip1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: install
-        args: --git https://github.com/0xPolygonMiden/compiler --branch next cargo-miden
+        args: --git https://github.com/0xMiden/compiler --branch next cargo-miden
     - name: Run `cargo miden new` command with program template
       run: cargo miden new my-program-proj --template-path=./program
     - name: Run `cargo miden build` command

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miden project starter templates
 
-This repository contains the official starter project templates for a [Miden cargo extension](https://github.com/0xPolygonMiden/compiler/cargo-ext) `new` command.  
+This repository contains the official starter project templates for a [Miden cargo extension](https://github.com/0xMiden/compiler/cargo-ext) `new` command.  
 
 ## Pre-requisites
 

--- a/account/template/Cargo.toml
+++ b/account/template/Cargo.toml
@@ -14,11 +14,11 @@ crate-type = ["cdylib"]
 {% if compiler_path %}
 miden = { path = "{{ compiler_path }}/sdk/sdk" }
 {% elsif compiler_branch %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler", branch = "{{ compiler_branch }}" }
+miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_branch }}" }
 {% elsif compiler_rev %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler", rev = "{{ compiler_rev }}" }
+miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+miden = { git = "https://github.com/0xMiden/compiler" }
 {% endif %}
 wit-bindgen-rt = "0.28"
 

--- a/account/template/README.md
+++ b/account/template/README.md
@@ -2,7 +2,7 @@
 
 ## Useful commands
 
-`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).  
+`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xMiden/compiler).  
 
 `cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.

--- a/account/template/rust-toolchain.toml
+++ b/account/template/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-03-20"
 components = ["rustfmt", "rust-src"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/note/template/Cargo.toml
+++ b/note/template/Cargo.toml
@@ -14,11 +14,11 @@ crate-type = ["cdylib"]
 {% if compiler_path %}
 miden = { path = "{{ compiler_path }}/sdk/sdk" }
 {% elsif compiler_branch %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler", branch = "{{ compiler_branch }}" }
+miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_branch }}" }
 {% elsif compiler_rev %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler", rev = "{{ compiler_rev }}" }
+miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+miden = { git = "https://github.com/0xMiden/compiler" }
 {% endif %}
 wit-bindgen-rt = "0.28"
 

--- a/note/template/README.md
+++ b/note/template/README.md
@@ -7,7 +7,7 @@ If you already have counter contract under different name all `counter-contract`
 
 ## Useful commands
 
-`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).  
+`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xMiden/compiler).  
 
 `cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.

--- a/note/template/rust-toolchain.toml
+++ b/note/template/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-03-20"
 components = ["rustfmt", "rust-src"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"

--- a/program/template/Cargo.toml
+++ b/program/template/Cargo.toml
@@ -14,11 +14,11 @@ crate-type = ["cdylib"]
 {% if compiler_path %}
 miden = { path = "{{ compiler_path }}/sdk/sdk" }
 {% elsif compiler_branch %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler", branch = "{{ compiler_branch }}" }
+miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_branch }}" }
 {% elsif compiler_rev %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler", rev = "{{ compiler_rev }}" }
+miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xPolygonMiden/compiler" }
+miden = { git = "https://github.com/0xMiden/compiler" }
 {% endif %}
 
 [profile.release]

--- a/program/template/README.md
+++ b/program/template/README.md
@@ -2,7 +2,7 @@
 
 ## Useful commands
 
-`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xPolygonMiden/compiler).  
+`{{crate_name}}` is built using the [Miden compiler](https://github.com/0xMiden/compiler).  
 
 `cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
 for more details on how to build and run the compiled programs.

--- a/program/template/rust-toolchain.toml
+++ b/program/template/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-03-20"
 components = ["rustfmt", "rust-src"]
-targets = ["wasm32-wasi"]
+targets = ["wasm32-wasip1"]
 profile = "minimal"


### PR DESCRIPTION
The `v0.10.0` tag is set to the last commit in this PR.