### PR TITLE
chore: fix documentation URLs in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miden project starter templates
 
-This repository contains the official starter project templates for a [Miden cargo extension](https://github.com/0xMiden/compiler/cargo-ext) `new` command.  
+This repository contains the official starter project templates for a [Miden cargo extension](https://0xmiden.github.io/compiler/usage/cargo-miden.html) `new` command.  
 
 ## Pre-requisites
 

--- a/account/template/README.md
+++ b/account/template/README.md
@@ -4,7 +4,7 @@
 
 `{{crate_name}}` is built using the [Miden compiler](https://github.com/0xMiden/compiler).  
 
-`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xmiden.github.io/compiler/usage/cargo-miden.html)
 for more details on how to build and run the compiled programs.
 
 

--- a/note/template/README.md
+++ b/note/template/README.md
@@ -9,7 +9,7 @@ If you already have counter contract under different name all `counter-contract`
 
 `{{crate_name}}` is built using the [Miden compiler](https://github.com/0xMiden/compiler).  
 
-`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xmiden.github.io/compiler/usage/cargo-miden.html)
 for more details on how to build and run the compiled programs.
 
 

--- a/program/template/README.md
+++ b/program/template/README.md
@@ -4,7 +4,7 @@
 
 `{{crate_name}}` is built using the [Miden compiler](https://github.com/0xMiden/compiler).  
 
-`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xpolygonmiden.github.io/compiler/usage/cargo-miden/#compiling-to-miden-assembly)
+`cargo miden` is a `cargo` cargo extension. Check out its [documentation](https://0xmiden.github.io/compiler/usage/cargo-miden.html)
 for more details on how to build and run the compiled programs.
 
 


### PR DESCRIPTION
The `v0.10.0` tag now points to the last commit in this PR.