### PR TITLE
[1/x] Set `miden` crate to version "0.4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,8 @@ jobs:
     - name: Run `cargo miden build` command
       run: cargo miden build --release
       working-directory: my-program-proj
+    - name: Run `cargo miden new` command with account template
+      run: cargo miden new my-account-proj --template-path=./account
+    - name: Run `cargo miden build` command
+      run: cargo miden build --release
+      working-directory: my-account-proj

--- a/account/template/Cargo.toml
+++ b/account/template/Cargo.toml
@@ -18,7 +18,7 @@ miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_bra
 {% elsif compiler_rev %}
 miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xMiden/compiler" }
+miden = { version = "0.4" }
 {% endif %}
 wit-bindgen-rt = "0.28"
 

--- a/note/template/Cargo.toml
+++ b/note/template/Cargo.toml
@@ -18,7 +18,7 @@ miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_bra
 {% elsif compiler_rev %}
 miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xMiden/compiler" }
+miden = { version = "0.4" }
 {% endif %}
 wit-bindgen-rt = "0.28"
 

--- a/program/template/Cargo.toml
+++ b/program/template/Cargo.toml
@@ -16,6 +16,6 @@ miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_bra
 {% elsif compiler_rev %}
 miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xMiden/compiler" }
+miden = { version = "0.4" }
 {% endif %}
 

--- a/tx-script/template/Cargo.toml
+++ b/tx-script/template/Cargo.toml
@@ -18,7 +18,7 @@ miden = { git = "https://github.com/0xMiden/compiler", branch = "{{ compiler_bra
 {% elsif compiler_rev %}
 miden = { git = "https://github.com/0xMiden/compiler", rev = "{{ compiler_rev }}" }
 {% else %}
-miden = { git = "https://github.com/0xMiden/compiler" }
+miden = { version = "0.4" }
 {% endif %}
 wit-bindgen-rt = "0.28"
 


### PR DESCRIPTION
As suggested in https://github.com/0xMiden/compiler/issues/628#issuecomment-3291642177

The tag `v0.14.0` used by the `0.4.1`(current) release is set to the last commit in this branch.